### PR TITLE
:gem: Bump ruby from 3.0 to 3.1 / Bump nokogiri from 1.12 to 1.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.0'
+        ruby-version: '3.1'
     - name: bundle install
       run: |
         gem install bundler

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem 'github-pages', group: :jekyll_plugins
 gem 'jekyll'
 gem 'rake'
 gem 'webrick'
+gem 'net-ftp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,7 @@ GEM
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.9)
+    date (3.2.2)
     dnsruby (1.61.7)
       simpleidn (~> 0.1)
     em-websocket (0.5.3)
@@ -105,6 +106,7 @@ GEM
     http_parser.rb (0.8.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
+    io-wait (0.2.1)
     jekyll (3.9.0)
       addressable (~> 2.4)
       colorator (~> 1.0)
@@ -229,6 +231,12 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.15.0)
     multipart-post (2.1.1)
+    net-ftp (0.1.3)
+      net-protocol
+      time
+    net-protocol (0.1.2)
+      io-wait
+      timeout
     nokogiri (1.13.1)
       mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
@@ -263,6 +271,9 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
+    time (0.2.0)
+      date
+    timeout (0.2.0)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
     tzinfo (1.2.9)
@@ -280,6 +291,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   jekyll
+  net-ftp
   rake
   webrick
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -296,4 +296,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.2.32
+   2.3.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -222,15 +222,15 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.3.6)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.7.1)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.15.0)
     multipart-post (2.1.1)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.1)
+      mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
     octokit (4.21.0)
       faraday (>= 0.9)
@@ -284,4 +284,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.2.3
+   2.2.32


### PR DESCRIPTION
To work with Ruby 3.1, I made changes:

- bump nokogiri gem
- add net-ftp gem
  - To fix `cannot load such file -- net/ftp (LoadError)`
- bump bundler to the latest